### PR TITLE
Virtual_PATH, Added trailing '/' to proxy_pass

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -168,7 +168,7 @@ server {
 			{{ $sum := sha1 $path }}
 			{{ $suffix := printf "-%s" $sum }}
 			location {{ $path }} {
-				proxy_pass http://{{ $host }}{{ $suffix }};
+				proxy_pass http://{{ $host }}{{ $suffix }}/;
 				{{ if (exists (printf "/etc/nginx/htpasswd/%s" $host)) }}
 				auth_basic	"Restricted {{ $host }}";
 				auth_basic_user_file	{{ (printf "/etc/nginx/htpasswd/%s" $host) }};

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -39,7 +39,7 @@ server {
 
 {{ define "upstream" }}
 upstream {{ .Host }}{{ .Suffix }} {
-{{ range $index, $container := .Containers }}
+{{ range $container := .Containers }}
 	{{ $addrLen := len $container.Addresses }}
 	{{/* If only 1 port exposed, use that */}}
 	{{ if eq $addrLen 1 }}

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -138,6 +138,10 @@ server {
 			{{ $suffix := printf "-%s" $sum }}
 			location {{ $path }} {
 				proxy_pass http://{{ $host }}{{ $suffix }};
+				{{ if (exists (printf "/etc/nginx/htpasswd/%s" $host)) }}
+				auth_basic	"Restricted {{ $host }}";
+				auth_basic_user_file	{{ (printf "/etc/nginx/htpasswd/%s" $host) }};
+				{{ end }}
 			}
 		{{ end }}
 	{{ end }}
@@ -165,6 +169,10 @@ server {
 			{{ $suffix := printf "-%s" $sum }}
 			location {{ $path }} {
 				proxy_pass http://{{ $host }}{{ $suffix }};
+				{{ if (exists (printf "/etc/nginx/htpasswd/%s" $host)) }}
+				auth_basic	"Restricted {{ $host }}";
+				auth_basic_user_file	{{ (printf "/etc/nginx/htpasswd/%s" $host) }};
+				{{ end }}
 			}
 		{{ end }}
 	{{ end }}

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -37,10 +37,9 @@ server {
 	return 503;
 }
 
-{{ range $host, $containers := groupByMulti $ "Env.VIRTUAL_HOST" "," }}
-
-upstream {{ $host }} {
-{{ range $container := $containers }}
+{{ define "upstream" }}
+upstream {{ .Host }}{{ .Suffix }} {
+{{ range $index, $container := .Containers }}
 	{{ $addrLen := len $container.Addresses }}
 	{{/* If only 1 port exposed, use that */}}
 	{{ if eq $addrLen 1 }}
@@ -67,6 +66,20 @@ upstream {{ $host }} {
 	{{ end }}
 {{ end }}
 }
+{{ end }}
+
+{{ range $host, $containers := groupByMulti $ "Env.VIRTUAL_HOST" "," }}
+{{ $paths := groupBy $containers "Env.VIRTUAL_PATH" }}
+{{ $pathCount := len $paths }}
+{{ if eq $pathCount 0 }}
+	{{ template "upstream" dict "Host" $host "Suffix" "" "Containers" $containers }}
+{{ else }}
+	{{ range $path, $containers := $paths }}
+		{{ $sum := sha1 $path }}
+		{{ $suffix := printf "-%s" $sum }}
+		{{ template "upstream" dict "Host" $host "Suffix" $suffix "Containers" $containers }}
+	{{ end }}
+{{ end }}
 
 {{/* Get the VIRTUAL_PROTO defined by containers w/ the same vhost, falling back to "http" */}}
 {{ $proto := or (first (groupByKeys $containers "Env.VIRTUAL_PROTO")) "http" }}
@@ -111,6 +124,7 @@ server {
 	include {{ printf "/etc/nginx/vhost.d/%s" $host }};
 	{{ end }}
 
+	{{ if eq $pathCount 0 }}
 	location / {
 		proxy_pass {{ $proto }}://{{ $host }};
 		{{ if (exists (printf "/etc/nginx/htpasswd/%s" $host)) }}
@@ -118,6 +132,15 @@ server {
 		auth_basic_user_file	{{ (printf "/etc/nginx/htpasswd/%s" $host) }};
 		{{ end }}
 	}
+	{{ else }}
+		{{ range $path, $containers := $paths }}
+			{{ $sum := sha1 $path }}
+			{{ $suffix := printf "-%s" $sum }}
+			location {{ $path }} {
+				proxy_pass http://{{ $host }}{{ $suffix }};
+			}
+		{{ end }}
+	{{ end }}
 }
 {{ else }}
 
@@ -128,6 +151,7 @@ server {
 	include {{ printf "/etc/nginx/vhost.d/%s" $host }};
 	{{ end }}
 
+	{{ if eq $pathCount 0 }}
 	location / {
 		proxy_pass {{ $proto }}://{{ $host }};
 		{{ if (exists (printf "/etc/nginx/htpasswd/%s" $host)) }}
@@ -135,6 +159,15 @@ server {
 		auth_basic_user_file	{{ (printf "/etc/nginx/htpasswd/%s" $host) }};
 		{{ end }}
 	}
+	{{ else }}
+		{{ range $path, $containers := $paths }}
+			{{ $sum := sha1 $path }}
+			{{ $suffix := printf "-%s" $sum }}
+			location {{ $path }} {
+				proxy_pass http://{{ $host }}{{ $suffix }};
+			}
+		{{ end }}
+	{{ end }}
 }
 
 {{ if (and (exists "/etc/nginx/certs/default.crt") (exists "/etc/nginx/certs/default.key")) }}


### PR DESCRIPTION
For me to successfully get Virtual_Path's to work, I had to add a trailing slash (/) to the proxy_pass url. Otherwise the proxy would append the path when proxying requests.
